### PR TITLE
Specify fluentd version

### DIFF
--- a/fluent-plugin-sflow.gemspec
+++ b/fluent-plugin-sflow.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.extensions    = ["ext/sflowtool/extconf.rb"]
 
-  spec.add_dependency "fluentd", "~>0.12.0"
+  spec.add_dependency "fluentd", "~> 0.12.40"
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rake-compiler", "~> 1.0"


### PR DESCRIPTION
It need specify version to avoid following problem.

ref:
Fix load order to avoid file not found when plugins have own native extension
https://github.com/fluent/fluentd/pull/1670